### PR TITLE
make Makefile more portable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,14 @@ objects=nsm.o DateTimeInfo.o Directory.o Filename.o PageBuilder.o PageInfo.o Pat
 cppfiles=nsm.cpp DateTimeInfo.cpp Directory.cpp Filename.cpp PageBuilder.cpp PageInfo.cpp Path.cpp Quoted.cpp SiteInfo.cpp Title.cpp
 CC=${CXX}
 LINK=-pthread
-CXXFLAGS=-std=c++11 -Wall -Wextra -pedantic -O3
+CXXFLAGS+= -std=c++11 -Wall -Wextra -pedantic -O3
 #Flags to use when compiling for Chocolatey
 #CXXFLAGS=-std=c++11 -Wall -Wextra -pedantic -O3 -static -static-libgcc -static-libstdc++
+DESTDIR?=
+PREFIX?=/usr/local
+BINDIR=${DESTDIR}${PREFIX}/bin
+
+all: nsm
 
 nsm: $(objects)
 	$(CC) $(CXXFLAGS) $(cppfiles) -o nsm $(LINK)
@@ -45,23 +50,15 @@ linux-gedit-highlighting:
 	chmod 644 html.lang
 	cp html.lang /usr/share/gtksourceview-3.0/language-specs/html.lang
 
-linux-install:
+install:
+	mkdir -p ${BINDIR}
 	chmod 755 nsm
-	mv nift /usr/local/bin
-	mv nsm /usr/local/bin
+	mv nift ${BINDIR}
+	mv nsm ${BINDIR}
 
-linux-uninstall:
-	rm /usr/local/bin/nift
-	rm /usr/local/bin/nsm
-
-osx-install:
-	chmod 755 nsm
-	mv nift /usr/local/bin
-	mv nsm /usr/local/bin
-
-osx-uninstall:
-	rm /usr/local/bin/nift
-	rm /usr/local/bin/nsm 
+uninstall:
+	rm ${BINDIR}/nift
+	rm ${BINDIR}/nsm
 
 git-bash-install:
 	chmod 755 nsm

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #basic makefile for nsm
 objects=nsm.o DateTimeInfo.o Directory.o Filename.o PageBuilder.o PageInfo.o Path.o Quoted.o SiteInfo.o Title.o
 cppfiles=nsm.cpp DateTimeInfo.cpp Directory.cpp Filename.cpp PageBuilder.cpp PageInfo.cpp Path.cpp Quoted.cpp SiteInfo.cpp Title.cpp
-CC=${CXX}
+CXX?=g++
 LINK=-pthread
 CXXFLAGS+= -std=c++11 -Wall -Wextra -pedantic -O3
 #Flags to use when compiling for Chocolatey
@@ -13,38 +13,38 @@ BINDIR=${DESTDIR}${PREFIX}/bin
 all: nsm
 
 nsm: $(objects)
-	$(CC) $(CXXFLAGS) $(cppfiles) -o nsm $(LINK)
-	$(CC) $(CXXFLAGS) $(cppfiles) -o nift $(LINK)
+	$(CXX) $(CXXFLAGS) $(cppfiles) -o nsm $(LINK)
+	$(CXX) $(CXXFLAGS) $(cppfiles) -o nift $(LINK)
 
 nsm.o: nsm.cpp SiteInfo.o Timer.h
-	$(CC) $(CXXFLAGS) -c -o $@ $< $(LINK)
+	$(CXX) $(CXXFLAGS) -c -o $@ $< $(LINK)
 
 SiteInfo.o: SiteInfo.cpp SiteInfo.h PageBuilder.o
-	$(CC) $(CXXFLAGS) -c -o $@ $< $(LINK)
+	$(CXX) $(CXXFLAGS) -c -o $@ $< $(LINK)
 
 PageBuilder.o: PageBuilder.cpp PageBuilder.h DateTimeInfo.o PageInfo.o
-	$(CC) $(CXXFLAGS) -c -o $@ $<
+	$(CXX) $(CXXFLAGS) -c -o $@ $<
 
 DateTimeInfo.o: DateTimeInfo.cpp DateTimeInfo.h
-	$(CC) $(CXXFLAGS) -c -o $@ $<
+	$(CXX) $(CXXFLAGS) -c -o $@ $<
 
 PageInfo.o: PageInfo.cpp PageInfo.h Path.o Title.o
-	$(CC) $(CXXFLAGS) -c -o $@ $<
+	$(CXX) $(CXXFLAGS) -c -o $@ $<
 
 Path.o: Path.cpp Path.h Directory.o Filename.o
-	$(CC) $(CXXFLAGS) -c -o $@ $<
+	$(CXX) $(CXXFLAGS) -c -o $@ $<
 
 Directory.o: Directory.cpp Directory.h Quoted.h
-	$(CC) $(CXXFLAGS) -c -o $@ $<
+	$(CXX) $(CXXFLAGS) -c -o $@ $<
 
 Filename.o: Filename.cpp Filename.h Quoted.h
-	$(CC) $(CXXFLAGS) -c -o $@ $<
+	$(CXX) $(CXXFLAGS) -c -o $@ $<
 
 Title.o: Title.cpp Title.h Quoted.o
-	$(CC) $(CXXFLAGS) -c -o $@ $<
+	$(CXX) $(CXXFLAGS) -c -o $@ $<
 
 Quoted.o: Quoted.cpp Quoted.h
-	$(CC) $(CXXFLAGS) -c -o $@ $<
+	$(CXX) $(CXXFLAGS) -c -o $@ $<
 
 linux-gedit-highlighting:
 	chmod 644 html.lang

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #basic makefile for nsm
 objects=nsm.o DateTimeInfo.o Directory.o Filename.o PageBuilder.o PageInfo.o Path.o Quoted.o SiteInfo.o Title.o
 cppfiles=nsm.cpp DateTimeInfo.cpp Directory.cpp Filename.cpp PageBuilder.cpp PageInfo.cpp Path.cpp Quoted.cpp SiteInfo.cpp Title.cpp
-CC=g++
+CC=${CXX}
 LINK=-pthread
 CXXFLAGS=-std=c++11 -Wall -Wextra -pedantic -O3
 #Flags to use when compiling for Chocolatey


### PR DESCRIPTION
Hi,

I am in the progress of packaging nsm for http://pkgsrc.org .
While I was working on it, I had to add two workarounds:

1. the build works with at least clang++ and g++, so using $CXX instead of hardcoded g++ makes more sense.
2. hardcoding paths makes it difficult to package, adding a generic target for Unix-like systems and keeping an install-windows, uninstall-windows would be better. Adding PREFIX and DESTDIR makes the build more flexible for us and other packaging systems (and less duplicated code across projects).

The += works with both gmake and netbsd make. If it causes problems with whatever you use on Windows, just remove it. The idea was to append to existing CXXFLAGS.