### PR TITLE
Eliminating unnecessary buffer flushes during non critical file IO.

### DIFF
--- a/PageBuilder.cpp
+++ b/PageBuilder.cpp
@@ -299,7 +299,7 @@ int PageBuilder::build(const PageInfo &PageToBuild, std::ostream& os)
         //writes page info file
         std::ofstream infoStream(pageInfoPath.str());
         infoStream << dateTimeInfo.currentTime() << " " << dateTimeInfo.currentDate() << "\n";
-        infoStream << this->pageToBuild << "\n" << "\n";
+        infoStream << this->pageToBuild << "\n\n";
         for(auto pageDep=pageDeps.begin(); pageDep != pageDeps.end(); pageDep++)
             infoStream << *pageDep << "\n";
         infoStream.close();

--- a/PageBuilder.cpp
+++ b/PageBuilder.cpp
@@ -281,7 +281,7 @@ int PageBuilder::build(const PageInfo &PageToBuild, std::ostream& os)
 
         //writes processed page to page file
         std::ofstream pageStream(pageToBuild.pagePath.str());
-        pageStream << processedPage.str() << std::endl;
+        pageStream << processedPage.str() << "\n";
         pageStream.close();
 
         //makes sure user can't accidentally write to page file
@@ -298,10 +298,10 @@ int PageBuilder::build(const PageInfo &PageToBuild, std::ostream& os)
 
         //writes page info file
         std::ofstream infoStream(pageInfoPath.str());
-        infoStream << dateTimeInfo.currentTime() << " " << dateTimeInfo.currentDate() << std::endl;
-        infoStream << this->pageToBuild << std::endl << std::endl;
+        infoStream << dateTimeInfo.currentTime() << " " << dateTimeInfo.currentDate() << "\n";
+        infoStream << this->pageToBuild << "\n" << "\n";
         for(auto pageDep=pageDeps.begin(); pageDep != pageDeps.end(); pageDep++)
-            infoStream << *pageDep << std::endl;
+            infoStream << *pageDep << "\n";
         infoStream.close();
 
         //makes sure user can't accidentally write to info file
@@ -340,9 +340,9 @@ int PageBuilder::read_and_process(const Path &readPath, std::set<Path> antiDepsO
         {
             indentAmount = baseIndentAmount;
             if(codeBlockDepth)
-                processedPage << std::endl;
+                processedPage << "\n";
             else
-                processedPage << std::endl << baseIndentAmount;
+                processedPage << "\n" << baseIndentAmount;
         }
 
         for(size_t linePos=0; linePos<inLine.length();)


### PR DESCRIPTION
Replaced `std::endl` with `\n` in areas where output files were being generated. Anytime `std::endl` is called it also flushes the buffer, which isn't ideal when dealing with non critical file IO as you lose the benefit of the OS managing the buffer and deciding when to write intermediary results to disk. 

I ran some tests to see how big of a difference it actually made:

- Cloned the [10K page website](https://gitlab.com/hugo-vs-nift/test-website-nift) example you used to profile runtime
- Setup a script on my linux VM to run my version and the default version 100 times using the `nsm build-all` command and recorded individual and average elapsed time.
- Average of each: `Original` - 10.0357 sec | `New version` - 8.18238 sec
- Raw results can be found [here](https://gist.github.com/patrick--/f76bf8d41d4423cbb552cd291a61d043)

As you mentioned in Discord, this performance benefit will only be seen when issuing a `nsm build-all` and not a `nsm build-update`. 