### PR TITLE
Don't force optimization level

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ objects=nsm.o DateTimeInfo.o Directory.o Filename.o FileSystem.o GitInfo.o PageB
 cppfiles=nsm.cpp DateTimeInfo.cpp Directory.cpp Filename.cpp FileSystem.cpp GitInfo.cpp PageBuilder.cpp PageInfo.cpp Path.cpp Quoted.cpp SiteInfo.cpp Title.cpp
 CXX?=g++
 LINK=-pthread
-CXXFLAGS+= -std=c++11 -Wall -Wextra -pedantic -O3
+CXXFLAGS?= -O3
+CXXFLAGS+= -std=c++11 -Wall -Wextra -pedantic
 #flags to use when compiling for Netlify
 #CXXFLAGS+= -std=c++11 -Wall -Wextra -pedantic -O3 -static-libgcc -static-libstdc++
 #Flags to use when compiling for Chocolatey


### PR DESCRIPTION
In most cases systemwide optimization/debug flags are provided through `CXXFLAGS`, and there should not be overridden. So instead of unconditionally appending `-O3`, respect system `CXXFLAGS`, but fallback to `-O3` if these are not defined.