### PR TITLE
Fix Makefile to not compile the same code 3 times

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,7 @@ BINDIR=${DESTDIR}${PREFIX}/bin
 all: nsm
 
 nsm: $(objects)
-	$(CXX) $(CXXFLAGS) $(cppfiles) -o nsm $(LINK)
-	$(CXX) $(CXXFLAGS) $(cppfiles) -o nift $(LINK)
+	$(CXX) $(CXXFLAGS) $(objects) -o nsm $(LINK)
 
 nsm.o: nsm.cpp GitInfo.o SiteInfo.o Timer.h
 	$(CXX) $(CXXFLAGS) -c -o $@ $< $(LINK)
@@ -61,8 +60,8 @@ linux-gedit-highlighting:
 install:
 	mkdir -p ${BINDIR}
 	chmod 755 nsm
-	mv nift ${BINDIR}
 	mv nsm ${BINDIR}
+	ln ${BINDIR}/nsm ${BINDIR}/nift
 
 uninstall:
 	rm ${BINDIR}/nift
@@ -70,8 +69,8 @@ uninstall:
 
 git-bash-install:
 	chmod 755 nsm
-	mv nift ~/bin
 	mv nsm ~/bin
+	ln ~/bin/nsm ~/bin/nift
 
 git-bash-uninstall:
 	rm ~/bin/nift
@@ -79,8 +78,8 @@ git-bash-uninstall:
 
 gitbash-install:
 	chmod 755 nsm
-	mv nift ~/bin
 	mv nsm ~/bin
+	ln ~/bin/nsm ~/bin/nift
 
 gitbash-uninstall:
 	rm ~/bin/nift


### PR DESCRIPTION
Currently, nift code is compiled 3 times:
- When building object files
- When building nift binary (object files are not used as sources are passed to the linker)
- When building nsm binary

So pass object files to the linker and only call it once, then create hardlink on installation.