### PR TITLE
Makefile improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.o
+nift
+nsm


### PR DESCRIPTION
Hi,

as pointed out in my Email earlier this month here is a proposal on a first fix for skipping luajit for distributions.
I think you might as well skip some FreeBSD parts as users will just use nsm from ports, but I haven't addressed it in this patch.
The gist of this work is that you should generally use $(MAKE) instead of make, use $(CXX) / $(CC) instead of gcc/clang, and that package managers are sometimes building with configurations you can't think about as developer (like pkgsrc does, we are on FreeBSD with gcc as well as clang), etc.