### PR TITLE
fix freebsd build issues

### DIFF
--- a/Lua.h
+++ b/Lua.h
@@ -16,16 +16,25 @@
 	#endif
 #else
 	#if defined __LUA_VERSION_5_3__
-		#include "/usr/local/include/lua.hpp"
-		#include "/usr/local/include/lualib.h"
-	    #include "/usr/local/include/lauxlib.h"
+		#if defined __FreeBSD__
+			#include "/usr/local/include/lua53/lua.hpp"
+			#include "/usr/local/include/lua53/lualib.h"
+			#include "/usr/local/include/lua53/lauxlib.h"
+		#else
+			#include "/usr/local/include/lua.hpp"
+			#include "/usr/local/include/lualib.h"
+			#include "/usr/local/include/lauxlib.h"
+		#endif
 	#else
-		#include "/usr/local/include/luajit-2.1/lua.hpp"
+		#if defined __FreeBSD__
+			#include "/usr/local/include/luajit-2.0/lua.hpp"
+		#else
+			#include "/usr/local/include/luajit-2.1/lua.hpp"
+		#endif
 	#endif
 #endif
 
 void process_lua_error(std::string& errStr, int& errLineNo);
-
 struct Lua
 {
 	bool initialised;

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ ifeq ($(BUNDLED),0)
 	    	#LINK+= -LLua-5.3/src -llua
 		else ifeq ($(detected_OS),FreeBSD)  # FreeBSD
 			CXXFLAGS+= -D__LUA_VERSION_5_3__
-	    	LINK+= -L/usr/local/lib -llua -lm -ldl  
+			LINK+= -L/usr/local/lib -llua-5.3 -lm -ldl
 		else                                # *nix
 			CXXFLAGS+= -D__LUA_VERSION_5_3__
 	    	LINK+= -L/usr/local/lib -llua -ldl
@@ -142,7 +142,7 @@ make-lua:
 ifeq ($(_BUNDLED_),0)
 else ifeq ($(WAS_UNBUNDLED),1)
 else ifeq ($(LUA_VERSION) $(detected_OS),5.3 FreeBSD)       # FreeBSD 
-	cd Lua-5.3 && make freebsd
+	cd Lua-5.3 && gmake freebsd
 else ifeq ($(LUA_VERSION) $(detected_OS),5.3 Linux)         # Linux
 	cd Lua-5.3 && make linux
 else ifeq ($(LUA_VERSION) $(detected_OS),5.3 Darwin)        # Mac OSX


### PR DESCRIPTION
These fixes are necessary in order to allow error-free builds on FreeBSD with the following options.

![Screenshot_2020-05-02_05_11_01_601541221](https://user-images.githubusercontent.com/2454895/80853737-67263780-8c33-11ea-81e0-de699f1f143a.png)
