### PR TITLE
fix 2.3.8 build issues on freebsd with lua 5.1/5.2 from ports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,22 @@ ifeq ($(BUNDLED),0)
 			CXXFLAGS+= -D__LUA_VERSION_5_3__
 	    	LINK+= -L/usr/local/lib -llua-5.3 -ldl
 		endif
+	else ifeq ($(LUA_VERSION),5.2) 
+	    ifeq ($(detected_OS),FreeBSD)  # FreeBSD
+			CXXFLAGS+= -D__LUA_VERSION_5_2__
+	    	LINK+= -L/usr/local/lib -llua-5.2 -lm -ldl  
+		else                                # *nix
+			CXXFLAGS+= -D__LUA_VERSION_5_2__
+	    	LINK+= -L/usr/local/lib -llua-5.2 -ldl
+		endif
+	else ifeq ($(LUA_VERSION),5.1) 
+	    ifeq ($(detected_OS),FreeBSD)  # FreeBSD
+			CXXFLAGS+= -D__LUA_VERSION_5_1__
+	    	LINK+= -L/usr/local/lib -llua-5.1 -lm -ldl  
+		else                                # *nix
+			CXXFLAGS+= -D__LUA_VERSION_5_1__
+	    	LINK+= -L/usr/local/lib -llua-5.1 -ldl
+		endif
 	else ifeq ($(LUAJIT_VERSION),2.0)
 		ifeq ($(detected_OS),FreeBSD)  # FreeBSD
 			CXXFLAGS+= -D__LUAJIT_VERSION_2_0__


### PR DESCRIPTION
I found it the corresponding parts for Lua 5.1/5.2 are missing from the Makefile for 2.3.8 release.

Now, the FreeBSD build supports the following options (LuaJIT 2.1 and Lua 5.4 are not available on FreeBSD, yet):
![Screenshot_2020-05-07_05_33_00_675444868](https://user-images.githubusercontent.com/2454895/81251855-9d452c00-9024-11ea-9a51-c25cd69371cf.png)
 