### PR TITLE
Makefile: restrict macOS LuaJIT flags to v2.0 only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ ifeq ($(CXX),clang)
 endif
 
 ifeq ($(detected_OS),Darwin)        # Mac OSX
-	CXXFLAGS+= -pagezero_size 10000 -image_base 10000000 -Qunused-arguments
+	CXXFLAGS+= -Qunused-arguments
 else ifeq ($(detected_OS),Windows)  # Windows
 	#use these flags for a smaller binary
 	CXXFLAGS+= -s -Wa,-mbig-obj -Wno-cast-function-type -Wno-error=cast-function-type
@@ -123,6 +123,9 @@ ifeq ($(BUNDLED),0)
 		else                                # *nix
 			CXXFLAGS+= -D__LUAJIT_VERSION_2_0__
 			LDFLAGS+= -ldl -L/usr/local/lib -lluajit-5.1 
+		endif
+		ifeq ($(detected_OS),Darwin)        # Mac OSX
+			CXXFLAGS+= -pagezero_size 10000 -image_base 10000000
 		endif
 	else
 		ifeq ($(detected_OS),FreeBSD)  # FreeBSD


### PR DESCRIPTION
I think the `-pagezero_size` and `-image_base` were added due to a bug in LuaJIT 2.0 on macOS. This was fixed in LuaJIT 2.1 as seen on an old copy of website (recent copies only recommend LuaJIT 2.1 on macOS) https://web.archive.org/web/20220407012421/http://luajit.org/install.html#embed

> _Important: this relates to LuaJIT 2.0 only — use LuaJIT 2.1 to avoid these complications._
> If you're building a 64 bit application on macOS which links directly or indirectly against LuaJIT, you need to link your main executable with these flags:
> ```
> -pagezero_size 10000 -image_base 100000000
> ```

---

Since bundled LuaJIT is 2.1, I think the flags only need to be set if system copy is LuaJIT 2.0.

As note, the `-pagezero_size`/`image_base` values are incompatible with ARM (M1) and will result in binaries that always segmentation fault.

---

I wasn't sure about `-Qunused-arguments` so just left that. Also, the `-image_base` number seems to be missing a zero, but I didn't modify it since I don't know if that was intentional.

I created separate `ifeq` rather than `else ifeq` since other flags should be same, but can change if preferred.