### PR TITLE
Enable installation to use lib64 if desired

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,9 @@ cppfiles=nsm.cpp ConsoleColor.cpp DateTimeInfo.cpp Directory.cpp Expr.cpp Exprtk
 
 DESTDIR?=
 PREFIX?=/usr/local
+LIB?=/lib
 BINDIR=${DESTDIR}${PREFIX}/bin
-LIBDIR=${DESTDIR}${PREFIX}/lib
+LIBDIR=${DESTDIR}${PREFIX}${LIB}
 
 CXX?=g++
 CXXFLAGS+=-std=c++11 -Wall -Wextra -pedantic -O3 -Dexprtk_disable_caseinsensitivity


### PR DESCRIPTION
On some systems libraries are installed in lib64, not in lib. This change enables specifying an alternate location such as lib64.