### PR TITLE
Fix freebsd build issues

### DIFF
--- a/exprtk/exprtk.h
+++ b/exprtk/exprtk.h
@@ -6340,7 +6340,7 @@ namespace exprtk
 
          void collect_nodes(typename expression_node<T>::noderef_list_t& node_delete_list)
          {
-            expression_node<T>::ndb_t::template collect(branch_, node_delete_list);
+            expression_node<T>::ndb_t::collect(branch_, node_delete_list);
          }
 
          std::size_t node_depth() const
@@ -6400,7 +6400,7 @@ namespace exprtk
 
          void collect_nodes(typename expression_node<T>::noderef_list_t& node_delete_list)
          {
-            expression_node<T>::ndb_t::template collect(branch_, node_delete_list);
+            expression_node<T>::ndb_t::collect(branch_, node_delete_list);
          }
 
          std::size_t node_depth() const
@@ -6463,7 +6463,7 @@ namespace exprtk
 
          void collect_nodes(typename expression_node<T>::noderef_list_t& node_delete_list)
          {
-            expression_node<T>::ndb_t::template collect(branch_, node_delete_list);
+            expression_node<T>::ndb_t::collect(branch_, node_delete_list);
          }
 
          std::size_t node_depth() const
@@ -6507,7 +6507,7 @@ namespace exprtk
 
          void collect_nodes(typename expression_node<T>::noderef_list_t& node_delete_list)
          {
-            expression_node<T>::ndb_t::template collect(branch_, node_delete_list);
+            expression_node<T>::ndb_t::collect(branch_, node_delete_list);
          }
 
          std::size_t node_depth() const
@@ -7782,7 +7782,7 @@ namespace exprtk
 
          void collect_nodes(typename expression_node<T>::noderef_list_t& node_delete_list)
          {
-            expression_node<T>::ndb_t::template collect(index_, node_delete_list);
+            expression_node<T>::ndb_t::collect(index_, node_delete_list);
          }
 
          std::size_t node_depth() const
@@ -11992,7 +11992,7 @@ namespace exprtk
 
          void collect_nodes(typename expression_node<T>::noderef_list_t& node_delete_list)
          {
-            expression_node<T>::ndb_t::template collect(branch_, node_delete_list);
+            expression_node<T>::ndb_t::collect(branch_, node_delete_list);
          }
 
          std::size_t node_depth() const
@@ -15283,7 +15283,7 @@ namespace exprtk
 
          void collect_nodes(typename expression_node<T>::noderef_list_t& node_delete_list)
          {
-            expression_node<T>::ndb_t::template collect(branch_, node_delete_list);
+            expression_node<T>::ndb_t::collect(branch_, node_delete_list);
          }
 
          std::size_t node_depth() const
@@ -15339,7 +15339,7 @@ namespace exprtk
 
          void collect_nodes(typename expression_node<T>::noderef_list_t& node_delete_list)
          {
-            expression_node<T>::ndb_t::template collect(branch_, node_delete_list);
+            expression_node<T>::ndb_t::collect(branch_, node_delete_list);
          }
 
          std::size_t node_depth() const
@@ -15406,7 +15406,7 @@ namespace exprtk
 
          void collect_nodes(typename expression_node<T>::noderef_list_t& node_delete_list)
          {
-            expression_node<T>::ndb_t::template collect(branch_, node_delete_list);
+            expression_node<T>::ndb_t::collect(branch_, node_delete_list);
          }
 
          std::size_t node_depth() const
@@ -15473,7 +15473,7 @@ namespace exprtk
 
          void collect_nodes(typename expression_node<T>::noderef_list_t& node_delete_list)
          {
-            expression_node<T>::ndb_t::template collect(branch_, node_delete_list);
+            expression_node<T>::ndb_t::collect(branch_, node_delete_list);
          }
 
          std::size_t node_depth() const
@@ -16040,7 +16040,7 @@ namespace exprtk
 
          void collect_nodes(typename expression_node<T>::noderef_list_t& node_delete_list)
          {
-            expression_node<T>::ndb_t::template collect(branch_, node_delete_list);
+            expression_node<T>::ndb_t::collect(branch_, node_delete_list);
          }
 
          std::size_t node_depth() const


### PR DESCRIPTION
On FreeBSD the latest Nift v3.0.3 fails to build:

```
=======================<phase: build          >============================
===== env: NO_DEPENDS=yes USER=root UID=0 GID=0
===>  Building for nift-3.0.3
clang -O2 -pipe -fstack-protector-strong -fno-strict-aliasing   -std=c++11 -Wall -Wextra -pedantic -O3 -Dexprtk_disable_caseinsensitivity -s -Qunused-arguments -lstdc++ -D__LUAJIT_VERSION_2_1__ -c -o ConsoleColor.o ConsoleColor.cpp
clang -O2 -pipe -fstack-protector-strong -fno-strict-aliasing   -std=c++11 -Wall -Wextra -pedantic -O3 -Dexprtk_disable_caseinsensitivity -s -Qunused-arguments -lstdc++ -D__LUAJIT_VERSION_2_1__ -c -o Directory.o Directory.cpp
clang -O2 -pipe -fstack-protector-strong -fno-strict-aliasing   -std=c++11 -Wall -Wextra -pedantic -O3 -Dexprtk_disable_caseinsensitivity -s -Qunused-arguments -lstdc++ -D__LUAJIT_VERSION_2_1__ -c -o Filename.o Filename.cpp
clang -O2 -pipe -fstack-protector-strong -fno-strict-aliasing   -std=c++11 -Wall -Wextra -pedantic -O3 -Dexprtk_disable_caseinsensitivity -s -Qunused-arguments -lstdc++ -D__LUAJIT_VERSION_2_1__ -c -o SystemInfo.o SystemInfo.cpp
clang -O2 -pipe -fstack-protector-strong -fno-strict-aliasing   -std=c++11 -Wall -Wextra -pedantic -O3 -Dexprtk_disable_caseinsensitivity -s -Qunused-arguments -lstdc++ -D__LUAJIT_VERSION_2_1__ -c -o DateTimeInfo.o DateTimeInfo.cpp
clang -O2 -pipe -fstack-protector-strong -fno-strict-aliasing   -std=c++11 -Wall -Wextra -pedantic -O3 -Dexprtk_disable_caseinsensitivity -s -Qunused-arguments -lstdc++ -D__LUAJIT_VERSION_2_1__ -c -o Expr.o Expr.cpp
clang -O2 -pipe -fstack-protector-strong -fno-strict-aliasing   -std=c++11 -Wall -Wextra -pedantic -O3 -Dexprtk_disable_caseinsensitivity -s -Qunused-arguments -lstdc++ -D__LUAJIT_VERSION_2_1__ -c -o Quoted.o Quoted.cpp
In file included from Expr.cpp:1:
In file included from ./Expr.h:8:
./exprtk/exprtk.h:6343:49: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
 6343 |             expression_node<T>::ndb_t::template collect(branch_, node_delete_list);
      |                                                 ^
./exprtk/exprtk.h:6403:49: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
 6403 |             expression_node<T>::ndb_t::template collect(branch_, node_delete_list);
      |                                                 ^
./exprtk/exprtk.h:6466:49: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
 6466 |             expression_node<T>::ndb_t::template collect(branch_, node_delete_list);
      |                                                 ^
./exprtk/exprtk.h:6510:49: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
 6510 |             expression_node<T>::ndb_t::template collect(branch_, node_delete_list);
      |                                                 ^
./exprtk/exprtk.h:7785:49: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
 7785 |             expression_node<T>::ndb_t::template collect(index_, node_delete_list);
      |                                                 ^
./exprtk/exprtk.h:11995:49: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
 11995 |             expression_node<T>::ndb_t::template collect(branch_, node_delete_list);
       |                                                 ^
./exprtk/exprtk.h:15286:49: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
 15286 |             expression_node<T>::ndb_t::template collect(branch_, node_delete_list);
       |                                                 ^
./exprtk/exprtk.h:15342:49: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
 15342 |             expression_node<T>::ndb_t::template collect(branch_, node_delete_list);
       |                                                 ^
./exprtk/exprtk.h:15409:49: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
 15409 |             expression_node<T>::ndb_t::template collect(branch_, node_delete_list);
       |                                                 ^
./exprtk/exprtk.h:15476:49: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
 15476 |             expression_node<T>::ndb_t::template collect(branch_, node_delete_list);
       |                                                 ^
./exprtk/exprtk.h:16043:49: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
 16043 |             expression_node<T>::ndb_t::template collect(branch_, node_delete_list);
       |                                                 
```

I've [already submitted these patches to the FreeBSD Ports](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=288379). It also builds fine on Gentoo.