### PR TITLE
Fix noParams overlapping comparisons always evaluate to false

### DIFF
--- a/nsm.cpp
+++ b/nsm.cpp
@@ -1452,7 +1452,7 @@ int main(int argc, const char* argv[])
 		else if(cmd == "watch")
 		{
 			//ensures correct number of parameters given
-			if(noParams < 2 && noParams > 5)
+			if(noParams < 2 || noParams > 5)
 				return parError(noParams, argv, "2-5");
 
 			WatchList wl;


### PR DESCRIPTION
Thanks to [one of the FreeBSD developers](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=288379#c2) and a LLVM/Clang warning, this commit fixes overlapping comparisons which always evaluate to false

```
nsm.cpp:1455:20: warning: overlapping comparisons always evaluate to false [-Wtautological-overlap-compare]
 1455 |                         if(noParams < 2 && noParams > 5)
      |                            ~~~~~~~~~~~~~^~~~~~~~~~~~~~~
1 warning generated.
```